### PR TITLE
Updating the github_repo_account variable to reflect the new name

### DIFF
--- a/repo_config.yaml
+++ b/repo_config.yaml
@@ -1,6 +1,6 @@
 repo_info:
   repo_name: umd_classes
-  github_repo_account: gpsaggese
+  github_repo_account: gpsaggese-org
   github_host_name: github.com
   invalid_words:
   issue_prefix: UmdTask


### PR DESCRIPTION
repo-config.yaml should show github_repo_account as gpsaggese-org and not gpsaggese

Pre-commit checks:
All checks passed ✅